### PR TITLE
Cleared up behavior of get operations

### DIFF
--- a/wicken/dictionary_dogma.py
+++ b/wicken/dictionary_dogma.py
@@ -48,7 +48,7 @@ class DictionaryDogma(dogma.Dogma):
         super(DictionaryDogma, self).__init__(religion, beliefs, dataObject)   
 
     def _get(self,key):        
-        return self._dataObject.get(key)
+        return self._dataObject[key]
         
     def _set(self,key,value):
         self._dataObject.__setitem__(key,value)

--- a/wicken/dogma.py
+++ b/wicken/dogma.py
@@ -50,7 +50,7 @@ class Tenets(object):
         except Exception as ex:
             exception_string = ''
             exception_string += '''Error getting the '%s' property of the class '%s'\n''' % (self.belief, dogma.__class__.__name__)
-            exception_string += '''Instance data object status: '%s'\n''' % dogma._dataObject
+            #exception_string += '''Instance data object status: '%s'\n''' % dogma._dataObject
             exception_string += '''Get operation raised exception: '%s' ''' % ex.__repr__()
             raise DogmaGetterSetterException(exception_string)
         
@@ -61,7 +61,7 @@ class Tenets(object):
         except Exception as ex:
             exception_string = ''
             exception_string += '''Error setting the '%s' property of the class '%s'\n''' % (self.belief, dogma.__class__.__name__)
-            exception_string += '''Instance data object status: '%s'\n''' % dogma._dataObject
+            #exception_string += '''Instance data object status: '%s'\n''' % dogma._dataObject
             exception_string += '''Set operation raised exception: '%s' ''' % ex.__repr__()
             raise DogmaGetterSetterException(exception_string)
         
@@ -71,7 +71,7 @@ class Tenets(object):
         except Exception as ex:
             exception_string = ''
             exception_string += '''Error deleting the '%s' property of the class '%s'\n''' % (self.belief, dogma.__class__.__name__)
-            exception_string += '''Instance data object status: '%s'\n''' % dogma._dataObject
+            #exception_string += '''Instance data object status: '%s'\n''' % dogma._dataObject
             exception_string += '''Delete operation raised exception: '%s' ''' % ex.__repr__()
             raise DogmaDeleteException(exception_string)
             

--- a/wicken/tests/dictionary_dogma_tests.py
+++ b/wicken/tests/dictionary_dogma_tests.py
@@ -94,12 +94,16 @@ class DictionaryDomgaTest(unittest.TestCase):
         d = DictionaryDogma('CF',beliefs,{'bar':'boo'})
        
         assert_equal(d._get('bar'),'boo')
-        assert_equal(d._get('bzzz'),None)
+        with assert_raises(KeyError):
+            d._get('bzzz')
         
         assert_equal(d.foo, 'boo') 
        
         with assert_raises(AttributeError):
             d.not_an_att
+            
+        with assert_raises(DogmaGetterSetterException):
+            d.bat
        
     def test_dogma_del(self):
     
@@ -113,20 +117,18 @@ class DictionaryDomgaTest(unittest.TestCase):
         d._dataObject['bar'] = 'bamboo'
         assert_equal(d.foo, 'bamboo')
         del d.foo
-        assert_equal(d._dataObject.get('bar'),None)
-        assert_equal(d.foo, None)
+        
+        assert_equal(d._dataObject.get('bar'), None)
+        
+        with assert_raises(DogmaGetterSetterException):
+            d.foo
         
         # Call it again!
         with assert_raises(DogmaDeleteException):
             del d.foo
         
-        
         with assert_raises(AttributeError):
             del d.not_an_att
-       
-       
-       
-       
             
     def test_dogma_validate_teaching(self):
 

--- a/wicken/tests/xml_dogma_tests.py
+++ b/wicken/tests/xml_dogma_tests.py
@@ -182,9 +182,11 @@ class XmlDomgaTest(unittest.TestCase):
 
         d = XmlDogma('Books',beliefs,dataObject)
         
-        assert_is(d._get('bzzz'),None)
+        with assert_raises(XmlDogmaException):
+            d._get('bzzz')
 
-        assert_is(d.book_title,None)
+        with assert_raises(DogmaGetterSetterException):
+            d.book_title
 
         with assert_raises(AttributeError):
             d.not_an_att
@@ -193,6 +195,7 @@ class XmlDomgaTest(unittest.TestCase):
     def test_dogma_get_element(self):
     
         beliefs = {'book_title':'/bookstore/book[1]/title',
+        'no_title':'/bookstore/book[5]/title',
         'childrens_title':"""/bookstore/book[@category = 'CHILDREN']/title""",
         'childrens_year':"""/bookstore/book[@category = 'CHILDREN']/year"""}
         dataObject = etree.parse(StringIO(BOOKS))        
@@ -206,6 +209,9 @@ class XmlDomgaTest(unittest.TestCase):
         assert_equal(d.childrens_title, 'Harry Potter')
         
         assert_equal(d.childrens_year, '2005')
+        
+        with assert_raises(DogmaGetterSetterException):
+            d.no_title
        
         
     def test_dogma_get_existing_attribute(self):
@@ -250,8 +256,11 @@ class XmlDomgaTest(unittest.TestCase):
         
         del d.book_category
 
-        assert_equal(d._get('/bookstore/book[1]/@category'),None)
-        assert_equal(d.book_category, None)
+        with assert_raises(XmlDogmaException):
+            d._get('/bookstore/book[1]/@category')
+            
+        with assert_raises(DogmaGetterSetterException):
+            assert_equal(d.book_category, None)
 
 
     def test_dogma_del_element(self):
@@ -265,8 +274,10 @@ class XmlDomgaTest(unittest.TestCase):
         
         del d.book_title
 
-        assert_equal(d._get('/bookstore/book[1]/title'),None)
-        assert_equal(d.book_title, None)
+        with assert_raises(XmlDogmaException):  
+            d._get('/bookstore/book[1]/title')
+        with assert_raises(DogmaGetterSetterException):
+            d.book_title
 
 
             

--- a/wicken/xml_dogma.py
+++ b/wicken/xml_dogma.py
@@ -61,10 +61,10 @@ class XmlDogma(dogma.Dogma):
             if result_length == 1:
                 result = result[0]
             elif result_length == 0:
-                return None
+                raise XmlDogmaException('Xpath expression "%s" returns zero elements!' % xpath) 
             else:
-                raise XmlDogmaException('Invalid xpath expression "%s" returns more than one element!' % xpath)
-                
+                raise XmlDogmaException('Xpath expression "%s" returns more than one element!' % xpath)      
+        
         if isinstance(result, etree._Element):
             #print type(result.text)
             result = result.text
@@ -197,7 +197,7 @@ class XmlDogma(dogma.Dogma):
         Check to make sure the teaching object which will be used as a dictionary key is hashable
         """
         if not isinstance(teaching, basestring):
-            raise XmlDogmaException('The belief "%s" does not have a valid teaching. The Teaching must be an xpath expression string. Received teaching: "%s" (type: %s)' % (belief, teaching, typeof(teaching)))
+            raise XmlDogmaException('The belief "%s" does not have a valid teaching. The Teaching must be an xpath expression string. Received teaching: "%s" (type: %s)' % (belief, teaching, type(teaching)))
         
         if teaching.startswith('//'):
             raise XmlDogmaException('The belief "%s" does not have a valid teaching. The Teaching must be a unique xpath expression which can not start with "//". Received teaching: "%s"' % (belief, teaching))


### PR DESCRIPTION
dogma.belief_does_not_exist raises an attribute error
dogma.value_does_not_exist raises a DogmaGetterSetterException
dogma.value_exists returns whatever the value is - could be None, "" or 'foobar'
