### PR TITLE
Allow extended-format mapping files to be used for beliefs instead of just simple dictionaries.

### DIFF
--- a/wicken/dogma.py
+++ b/wicken/dogma.py
@@ -107,11 +107,17 @@ class MetaReligion(type):
     
             if belief.startswith('_'):
                 raise DogmaMetaClassException('''Blasphemous belief! (property name: '%s') - even god can not make properties that start with an underscore''' % belief)
-    
+
+            if isinstance(teaching, dict):
+                doc      = teaching['desc']
+                teaching = teaching['query']
+            else:
+                doc      = cls._create_doc(belief, teaching)
+
             # use a class method from the Dogma class to validate the teaching        
             cls._validate_teaching(belief, teaching)
-              
-            clsDict[belief] = Tenets(belief, teaching, doc = cls._create_doc(belief,teaching))
+
+            clsDict[belief] = Tenets(belief, teaching, doc=doc)
         
         
         valid_propery_names = tuple(beliefs.keys())


### PR DESCRIPTION
This allows mappings generated by metamap (metamap.ioos.us) with full descriptions, eg:

```
{
  "comment": {
    "query": "/ncml:netcdf/ncml:attribute[@name='comment']/@value",
    "desc": "Miscellaneous information about the data.\t"
  },
  "time_coverage_resolution": {
    "query": "//ncml:attribute[@name='time_coverage_resolution']/@value)",
    "desc": "Describes the temporal coverage of the data as a time range.\t"
  },
  "geospatial_vertical_max": {
    "query": "/ncml:netcdf/ncml:attribute[@name='geospatial_vertical_max']/@value",
    "desc": "Describes a simple latitude, longitude, and vertical bounding box. For a more detailed geospatial coverage, see the suggested geospatial attributes.\n"
  },
```
